### PR TITLE
Fix text always being lowercased when typing

### DIFF
--- a/index.html
+++ b/index.html
@@ -567,7 +567,7 @@
             var result = "";
 
             for (var i = 0; i < text.length; i++) {
-                var letter = text[i].toLowerCase();
+                var letter = text[i];
                 if (runes[letter]) {
                     result += runes[letter];
                 } else {
@@ -657,7 +657,7 @@
             var result = "";
 
             for (var i = 0; i < text.length; i++) {
-                var letter = text[i].toLowerCase();
+                var letter = text[i];
                 if (runes[letter]) {
                     result += runes[letter];
                 } else {


### PR DESCRIPTION
When typing into the input box, all text in the box was being lowercased, resulting in only lowercase runes showing up. Removing the `toLowerCase` calls fixes that. I didn't find any new bugs that were introduced by this, but I'm not sure if removing the `toLowerCase` calls has any other unintended side effects.